### PR TITLE
feat: 新增 OAuth2 Token 签发记录管理

### DIFF
--- a/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
+++ b/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
@@ -57,7 +57,7 @@ public class WebSecurityConfig {
                         .permitAll()
                         .requestMatchers("/login/captcha/image")
                         .permitAll()
-                        .requestMatchers("/client", "/client/**", "/online-users", "/online-users/**", "/oauth2/activate*", "/oauth2/consent", "/", "/profile")
+                        .requestMatchers("/client", "/client/**", "/authorizations", "/authorizations/**", "/online-users", "/online-users/**", "/oauth2/activate*", "/oauth2/consent", "/", "/profile")
                         .authenticated());
         // 表单登录处理从授权服务器过滤器链
         httpSecurity

--- a/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
+++ b/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
@@ -14,6 +14,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -44,7 +46,9 @@ public class WebSecurityConfig {
      */
     @Bean
     @Order(2)
-    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
+    public SecurityFilterChain defaultSecurityFilterChain(
+            HttpSecurity httpSecurity,
+            JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
         log.info("Init HttpSecurity for Security");
         // web站点基本安全配置
         httpSecurity
@@ -57,7 +61,9 @@ public class WebSecurityConfig {
                         .permitAll()
                         .requestMatchers("/login/captcha/image")
                         .permitAll()
-                        .requestMatchers("/client", "/client/**", "/authorizations", "/authorizations/**", "/online-users", "/online-users/**", "/oauth2/activate*", "/oauth2/consent", "/", "/profile")
+                        .requestMatchers("/authorizations", "/authorizations/**")
+                        .hasAnyAuthority("ADMIN", "IT")
+                        .requestMatchers("/client", "/client/**", "/online-users", "/online-users/**", "/oauth2/activate*", "/oauth2/consent", "/", "/profile")
                         .authenticated());
         // 表单登录处理从授权服务器过滤器链
         httpSecurity
@@ -73,7 +79,22 @@ public class WebSecurityConfig {
                 .logoutSuccessHandler(logoutAuditSuccessHandler));
         // 添加BearerTokenAuthenticationFilter，将认证服务当做一个资源服务，解析请求头中的token
         httpSecurity.oauth2ResourceServer((resourceServer) -> resourceServer
-                .jwt(Customizer.withDefaults()));
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)));
         return httpSecurity.build();
+    }
+
+    /**
+     * 从 JWT roles 声明恢复应用角色，保证直连授权服务时也执行管理角色校验。
+     *
+     * @return JWT 认证转换器
+     */
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter authoritiesConverter = new JwtGrantedAuthoritiesConverter();
+        authoritiesConverter.setAuthoritiesClaimName("roles");
+        authoritiesConverter.setAuthorityPrefix("");
+        JwtAuthenticationConverter authenticationConverter = new JwtAuthenticationConverter();
+        authenticationConverter.setJwtGrantedAuthoritiesConverter(authoritiesConverter);
+        return authenticationConverter;
     }
 }

--- a/src/main/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepository.java
+++ b/src/main/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepository.java
@@ -85,8 +85,10 @@ public class OAuth2AuthorizationRecordRepository {
             arguments.add(param.getAuthorizationGrantType().trim());
         }
         if ("ACTIVE".equalsIgnoreCase(param.getStatus())) {
-            where.append(" AND (a.access_token_expires_at > CURRENT_TIMESTAMP")
-                    .append(" OR a.refresh_token_expires_at > CURRENT_TIMESTAMP)");
+            where.append(" AND a.access_token_expires_at > CURRENT_TIMESTAMP");
+        } else if ("REFRESHABLE".equalsIgnoreCase(param.getStatus())) {
+            where.append(" AND (a.access_token_expires_at IS NULL OR a.access_token_expires_at <= CURRENT_TIMESTAMP)")
+                    .append(" AND a.refresh_token_expires_at > CURRENT_TIMESTAMP");
         } else if ("EXPIRED".equalsIgnoreCase(param.getStatus())) {
             where.append(" AND (a.access_token_expires_at IS NULL OR a.access_token_expires_at <= CURRENT_TIMESTAMP)")
                     .append(" AND (a.refresh_token_expires_at IS NULL OR a.refresh_token_expires_at <= CURRENT_TIMESTAMP)");

--- a/src/main/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepository.java
+++ b/src/main/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepository.java
@@ -1,0 +1,139 @@
+package io.github.opensabre.authorization.dao;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
+import io.github.opensabre.authorization.entity.vo.OAuth2AuthorizationRecordVo;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class OAuth2AuthorizationRecordRepository {
+
+    private static final String SELECT_COLUMNS = """
+            SELECT a.id, c.client_id, c.client_name, a.principal_name,
+                   a.authorization_grant_type, a.authorized_scopes,
+                   a.access_token_type, a.access_token_issued_at,
+                   a.access_token_expires_at, a.refresh_token_issued_at,
+                   a.refresh_token_expires_at,
+                   CASE WHEN a.oidc_id_token_value IS NULL THEN 0 ELSE 1 END AS has_id_token,
+                   CASE WHEN a.device_code_value IS NULL THEN 0 ELSE 1 END AS has_device_code
+              FROM oauth2_authorization a
+              LEFT JOIN oauth2_registered_client c ON c.id = a.registered_client_id
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public OAuth2AuthorizationRecordRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public IPage<OAuth2AuthorizationRecordVo> query(Page<?> page, OAuth2AuthorizationQueryParam param) {
+        SqlCondition condition = buildCondition(param);
+        Long total = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_authorization a "
+                        + "LEFT JOIN oauth2_registered_client c ON c.id = a.registered_client_id "
+                        + condition.whereClause(),
+                Long.class,
+                condition.arguments().toArray());
+
+        List<Object> arguments = new ArrayList<>(condition.arguments());
+        arguments.add(page.getSize());
+        arguments.add(page.offset());
+        List<OAuth2AuthorizationRecordVo> records = jdbcTemplate.query(
+                SELECT_COLUMNS + condition.whereClause()
+                        + " ORDER BY a.access_token_issued_at DESC, a.id DESC LIMIT ? OFFSET ?",
+                rowMapper(),
+                arguments.toArray());
+
+        Page<OAuth2AuthorizationRecordVo> result =
+                new Page<>(page.getCurrent(), page.getSize(), total == null ? 0 : total);
+        result.setRecords(records);
+        return result;
+    }
+
+    public Optional<OAuth2AuthorizationRecordVo> findById(String id) {
+        List<OAuth2AuthorizationRecordVo> records = jdbcTemplate.query(
+                SELECT_COLUMNS + " WHERE a.id = ?",
+                rowMapper(),
+                id);
+        return records.stream().findFirst();
+    }
+
+    private SqlCondition buildCondition(OAuth2AuthorizationQueryParam param) {
+        StringBuilder where = new StringBuilder(" WHERE 1 = 1");
+        List<Object> arguments = new ArrayList<>();
+        if (StringUtils.isNotBlank(param.getClientId())) {
+            where.append(" AND c.client_id LIKE ?");
+            arguments.add("%" + param.getClientId().trim() + "%");
+        }
+        if (StringUtils.isNotBlank(param.getPrincipalName())) {
+            where.append(" AND a.principal_name LIKE ?");
+            arguments.add("%" + param.getPrincipalName().trim() + "%");
+        }
+        if (StringUtils.isNotBlank(param.getAuthorizationGrantType())) {
+            where.append(" AND a.authorization_grant_type = ?");
+            arguments.add(param.getAuthorizationGrantType().trim());
+        }
+        if ("ACTIVE".equalsIgnoreCase(param.getStatus())) {
+            where.append(" AND (a.access_token_expires_at > CURRENT_TIMESTAMP")
+                    .append(" OR a.refresh_token_expires_at > CURRENT_TIMESTAMP)");
+        } else if ("EXPIRED".equalsIgnoreCase(param.getStatus())) {
+            where.append(" AND (a.access_token_expires_at IS NULL OR a.access_token_expires_at <= CURRENT_TIMESTAMP)")
+                    .append(" AND (a.refresh_token_expires_at IS NULL OR a.refresh_token_expires_at <= CURRENT_TIMESTAMP)");
+        }
+        return new SqlCondition(where.toString(), arguments);
+    }
+
+    private RowMapper<OAuth2AuthorizationRecordVo> rowMapper() {
+        return (resultSet, rowNum) -> {
+            OAuth2AuthorizationRecordVo record = new OAuth2AuthorizationRecordVo();
+            record.setId(resultSet.getString("id"));
+            record.setClientId(resultSet.getString("client_id"));
+            record.setClientName(resultSet.getString("client_name"));
+            record.setPrincipalName(resultSet.getString("principal_name"));
+            record.setAuthorizationGrantType(resultSet.getString("authorization_grant_type"));
+            record.setAuthorizedScopes(resultSet.getString("authorized_scopes"));
+            record.setAccessTokenType(resultSet.getString("access_token_type"));
+            record.setAccessTokenIssuedAt(toDate(resultSet.getTimestamp("access_token_issued_at")));
+            record.setAccessTokenExpiresAt(toDate(resultSet.getTimestamp("access_token_expires_at")));
+            record.setRefreshTokenIssuedAt(toDate(resultSet.getTimestamp("refresh_token_issued_at")));
+            record.setRefreshTokenExpiresAt(toDate(resultSet.getTimestamp("refresh_token_expires_at")));
+            record.setHasIdToken(resultSet.getBoolean("has_id_token"));
+            record.setHasDeviceCode(resultSet.getBoolean("has_device_code"));
+            record.setStatus(resolveStatus(record));
+            return record;
+        };
+    }
+
+    private static Date toDate(Timestamp timestamp) {
+        return timestamp == null ? null : Date.from(timestamp.toInstant());
+    }
+
+    private static String resolveStatus(OAuth2AuthorizationRecordVo record) {
+        Instant now = Instant.now();
+        if (isAfter(record.getAccessTokenExpiresAt(), now)) {
+            return "ACTIVE";
+        }
+        if (isAfter(record.getRefreshTokenExpiresAt(), now)) {
+            return "REFRESHABLE";
+        }
+        return "EXPIRED";
+    }
+
+    private static boolean isAfter(Date value, Instant instant) {
+        return value != null && value.toInstant().isAfter(instant);
+    }
+
+    private record SqlCondition(String whereClause, List<Object> arguments) {
+    }
+}

--- a/src/main/java/io/github/opensabre/authorization/entity/form/OAuth2AuthorizationQueryForm.java
+++ b/src/main/java/io/github/opensabre/authorization/entity/form/OAuth2AuthorizationQueryForm.java
@@ -1,0 +1,18 @@
+package io.github.opensabre.authorization.entity.form;
+
+import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
+import io.github.opensabre.persistence.entity.form.BaseQueryForm;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class OAuth2AuthorizationQueryForm extends BaseQueryForm<OAuth2AuthorizationQueryParam> {
+
+    private String clientId;
+    private String principalName;
+    private String authorizationGrantType;
+    private String status;
+}

--- a/src/main/java/io/github/opensabre/authorization/entity/param/OAuth2AuthorizationQueryParam.java
+++ b/src/main/java/io/github/opensabre/authorization/entity/param/OAuth2AuthorizationQueryParam.java
@@ -1,0 +1,17 @@
+package io.github.opensabre.authorization.entity.param;
+
+import io.github.opensabre.persistence.entity.param.BaseParam;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class OAuth2AuthorizationQueryParam extends BaseParam {
+
+    private String clientId;
+    private String principalName;
+    private String authorizationGrantType;
+    private String status;
+}

--- a/src/main/java/io/github/opensabre/authorization/entity/vo/OAuth2AuthorizationRecordVo.java
+++ b/src/main/java/io/github/opensabre/authorization/entity/vo/OAuth2AuthorizationRecordVo.java
@@ -1,0 +1,24 @@
+package io.github.opensabre.authorization.entity.vo;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class OAuth2AuthorizationRecordVo {
+
+    private String id;
+    private String clientId;
+    private String clientName;
+    private String principalName;
+    private String authorizationGrantType;
+    private String authorizedScopes;
+    private String accessTokenType;
+    private Date accessTokenIssuedAt;
+    private Date accessTokenExpiresAt;
+    private Date refreshTokenIssuedAt;
+    private Date refreshTokenExpiresAt;
+    private boolean hasIdToken;
+    private boolean hasDeviceCode;
+    private String status;
+}

--- a/src/main/java/io/github/opensabre/authorization/rest/OAuth2AuthorizationRecordController.java
+++ b/src/main/java/io/github/opensabre/authorization/rest/OAuth2AuthorizationRecordController.java
@@ -5,6 +5,8 @@ import io.github.opensabre.authorization.entity.form.OAuth2AuthorizationQueryFor
 import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
 import io.github.opensabre.authorization.entity.vo.OAuth2AuthorizationRecordVo;
 import io.github.opensabre.authorization.service.IOAuth2AuthorizationRecordService;
+import io.github.opensabre.governance.audit.annotations.Audit;
+import io.github.opensabre.governance.audit.annotations.OperationType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,8 +44,16 @@ public class OAuth2AuthorizationRecordController {
         return authorizationRecordService.get(id);
     }
 
-    @Operation(summary = "撤销OAuth2授权记录")
+    @Operation(
+            summary = "终止OAuth2服务端授权",
+            description = "删除服务端授权记录并阻止Refresh Token继续使用；已签发的自包含JWT Access Token仍有效至过期")
     @DeleteMapping("/{id}")
+    @Audit(
+            operationType = OperationType.DELETE,
+            description = "终止OAuth2服务端授权",
+            module = "OAUTH2_AUTHORIZATION",
+            response = true,
+            key = "#id")
     public Boolean revoke(
             @Parameter(description = "授权记录ID", required = true) @PathVariable String id) {
         return authorizationRecordService.revoke(id);

--- a/src/main/java/io/github/opensabre/authorization/rest/OAuth2AuthorizationRecordController.java
+++ b/src/main/java/io/github/opensabre/authorization/rest/OAuth2AuthorizationRecordController.java
@@ -1,0 +1,51 @@
+package io.github.opensabre.authorization.rest;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.github.opensabre.authorization.entity.form.OAuth2AuthorizationQueryForm;
+import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
+import io.github.opensabre.authorization.entity.vo.OAuth2AuthorizationRecordVo;
+import io.github.opensabre.authorization.service.IOAuth2AuthorizationRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/authorizations")
+@Tag(name = "OAuth2授权记录")
+public class OAuth2AuthorizationRecordController {
+
+    private final IOAuth2AuthorizationRecordService authorizationRecordService;
+
+    public OAuth2AuthorizationRecordController(IOAuth2AuthorizationRecordService authorizationRecordService) {
+        this.authorizationRecordService = authorizationRecordService;
+    }
+
+    @Operation(summary = "分页查询OAuth2授权记录")
+    @PostMapping("/conditions")
+    public IPage<OAuth2AuthorizationRecordVo> search(@Valid @RequestBody OAuth2AuthorizationQueryForm form) {
+        return authorizationRecordService.query(
+                form.getPage(), form.toParam(OAuth2AuthorizationQueryParam.class));
+    }
+
+    @Operation(summary = "查看OAuth2授权记录")
+    @GetMapping("/{id}")
+    public OAuth2AuthorizationRecordVo get(
+            @Parameter(description = "授权记录ID", required = true) @PathVariable String id) {
+        return authorizationRecordService.get(id);
+    }
+
+    @Operation(summary = "撤销OAuth2授权记录")
+    @DeleteMapping("/{id}")
+    public Boolean revoke(
+            @Parameter(description = "授权记录ID", required = true) @PathVariable String id) {
+        return authorizationRecordService.revoke(id);
+    }
+}

--- a/src/main/java/io/github/opensabre/authorization/service/IOAuth2AuthorizationRecordService.java
+++ b/src/main/java/io/github/opensabre/authorization/service/IOAuth2AuthorizationRecordService.java
@@ -11,5 +11,12 @@ public interface IOAuth2AuthorizationRecordService {
 
     OAuth2AuthorizationRecordVo get(String id);
 
+    /**
+     * 删除服务端授权聚合并阻止刷新令牌继续使用。
+     * 自包含访问令牌不依赖该聚合校验，将持续有效至自身过期。
+     *
+     * @param id OAuth2授权记录ID
+     * @return 记录存在并已删除时返回true
+     */
     boolean revoke(String id);
 }

--- a/src/main/java/io/github/opensabre/authorization/service/IOAuth2AuthorizationRecordService.java
+++ b/src/main/java/io/github/opensabre/authorization/service/IOAuth2AuthorizationRecordService.java
@@ -1,0 +1,15 @@
+package io.github.opensabre.authorization.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
+import io.github.opensabre.authorization.entity.vo.OAuth2AuthorizationRecordVo;
+
+public interface IOAuth2AuthorizationRecordService {
+
+    IPage<OAuth2AuthorizationRecordVo> query(Page<?> page, OAuth2AuthorizationQueryParam param);
+
+    OAuth2AuthorizationRecordVo get(String id);
+
+    boolean revoke(String id);
+}

--- a/src/main/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordService.java
+++ b/src/main/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordService.java
@@ -34,6 +34,8 @@ public class OAuth2AuthorizationRecordService implements IOAuth2AuthorizationRec
 
     @Override
     public boolean revoke(String id) {
+        // Spring Authorization Server删除授权聚合后会拒绝后续刷新；
+        // 已签发的自包含JWT不依赖数据库校验，因此仍按自身过期时间失效。
         OAuth2Authorization authorization = authorizationService.findById(id);
         if (authorization == null) {
             return false;

--- a/src/main/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordService.java
+++ b/src/main/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordService.java
@@ -1,0 +1,44 @@
+package io.github.opensabre.authorization.service.impl;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.github.opensabre.authorization.dao.OAuth2AuthorizationRecordRepository;
+import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
+import io.github.opensabre.authorization.entity.vo.OAuth2AuthorizationRecordVo;
+import io.github.opensabre.authorization.service.IOAuth2AuthorizationRecordService;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OAuth2AuthorizationRecordService implements IOAuth2AuthorizationRecordService {
+
+    private final OAuth2AuthorizationRecordRepository repository;
+    private final OAuth2AuthorizationService authorizationService;
+
+    public OAuth2AuthorizationRecordService(OAuth2AuthorizationRecordRepository repository,
+                                            OAuth2AuthorizationService authorizationService) {
+        this.repository = repository;
+        this.authorizationService = authorizationService;
+    }
+
+    @Override
+    public IPage<OAuth2AuthorizationRecordVo> query(Page<?> page, OAuth2AuthorizationQueryParam param) {
+        return repository.query(page, param);
+    }
+
+    @Override
+    public OAuth2AuthorizationRecordVo get(String id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    @Override
+    public boolean revoke(String id) {
+        OAuth2Authorization authorization = authorizationService.findById(id);
+        if (authorization == null) {
+            return false;
+        }
+        authorizationService.remove(authorization);
+        return true;
+    }
+}

--- a/src/test/java/io/github/opensabre/authorization/config/WebSecurityConfigTest.java
+++ b/src/test/java/io/github/opensabre/authorization/config/WebSecurityConfigTest.java
@@ -1,0 +1,32 @@
+package io.github.opensabre.authorization.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebSecurityConfigTest {
+
+    @Test
+    void shouldRestoreAuthoritiesFromJwtRolesClaim() {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("admin")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(60))
+                .claim("roles", List.of("ADMIN", "IT"))
+                .build();
+
+        var authentication = new WebSecurityConfig()
+                .jwtAuthenticationConverter()
+                .convert(jwt);
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getAuthorities())
+                .extracting("authority")
+                .containsExactlyInAnyOrder("ADMIN", "IT");
+    }
+}

--- a/src/test/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepositoryTest.java
+++ b/src/test/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepositoryTest.java
@@ -1,0 +1,87 @@
+package io.github.opensabre.authorization.dao;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.github.opensabre.authorization.entity.param.OAuth2AuthorizationQueryParam;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuth2AuthorizationRecordRepositoryTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private OAuth2AuthorizationRecordRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        DriverManagerDataSource dataSource =
+                new DriverManagerDataSource("jdbc:h2:mem:oauth2-records;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "");
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("DROP ALL OBJECTS");
+        jdbcTemplate.execute("""
+                CREATE TABLE oauth2_registered_client (
+                    id VARCHAR(100) PRIMARY KEY,
+                    client_id VARCHAR(100),
+                    client_name VARCHAR(200)
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE oauth2_authorization (
+                    id VARCHAR(100) PRIMARY KEY,
+                    registered_client_id VARCHAR(100),
+                    principal_name VARCHAR(200),
+                    authorization_grant_type VARCHAR(100),
+                    authorized_scopes VARCHAR(1000),
+                    access_token_type VARCHAR(100),
+                    access_token_issued_at TIMESTAMP,
+                    access_token_expires_at TIMESTAMP,
+                    refresh_token_issued_at TIMESTAMP,
+                    refresh_token_expires_at TIMESTAMP,
+                    oidc_id_token_value BLOB,
+                    device_code_value BLOB
+                )
+                """);
+        jdbcTemplate.update(
+                "INSERT INTO oauth2_registered_client (id, client_id, client_name) VALUES (?, ?, ?)",
+                "client-record", "gateway-client", "Gateway");
+        repository = new OAuth2AuthorizationRecordRepository(jdbcTemplate);
+    }
+
+    @Test
+    void shouldKeepActiveAndRefreshableStatusesDistinct() {
+        Instant now = Instant.now();
+        insert("active", now.minusSeconds(30), now.plusSeconds(60), now.plusSeconds(120));
+        insert("refreshable", now.minusSeconds(30), now.minusSeconds(1), now.plusSeconds(120));
+        insert("expired", now.minusSeconds(120), now.minusSeconds(60), now.minusSeconds(1));
+
+        assertThat(query("ACTIVE")).containsExactly("active");
+        assertThat(query("REFRESHABLE")).containsExactly("refreshable");
+        assertThat(query("EXPIRED")).containsExactly("expired");
+    }
+
+    private java.util.List<String> query(String status) {
+        OAuth2AuthorizationQueryParam param = new OAuth2AuthorizationQueryParam();
+        param.setStatus(status);
+        return repository.query(new Page<>(1, 20), param).getRecords().stream()
+                .map(record -> record.getId())
+                .toList();
+    }
+
+    private void insert(String id, Instant issuedAt, Instant accessExpiresAt, Instant refreshExpiresAt) {
+        jdbcTemplate.update("""
+                        INSERT INTO oauth2_authorization (
+                            id, registered_client_id, principal_name, authorization_grant_type,
+                            authorized_scopes, access_token_type, access_token_issued_at,
+                            access_token_expires_at, refresh_token_issued_at, refresh_token_expires_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                id, "client-record", "operator", "authorization_code", "openid,profile", "Bearer",
+                Timestamp.from(issuedAt), Timestamp.from(accessExpiresAt),
+                Timestamp.from(issuedAt), Timestamp.from(refreshExpiresAt));
+    }
+}

--- a/src/test/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordServiceTest.java
+++ b/src/test/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordServiceTest.java
@@ -1,0 +1,37 @@
+package io.github.opensabre.authorization.service.impl;
+
+import io.github.opensabre.authorization.dao.OAuth2AuthorizationRecordRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OAuth2AuthorizationRecordServiceTest {
+
+    private final OAuth2AuthorizationRecordRepository repository =
+            mock(OAuth2AuthorizationRecordRepository.class);
+    private final OAuth2AuthorizationService authorizationService =
+            mock(OAuth2AuthorizationService.class);
+    private final OAuth2AuthorizationRecordService service =
+            new OAuth2AuthorizationRecordService(repository, authorizationService);
+
+    @Test
+    void shouldRemoveExistingAuthorizationWhenRevoked() {
+        OAuth2Authorization authorization = mock(OAuth2Authorization.class);
+        when(authorizationService.findById("authorization-id")).thenReturn(authorization);
+
+        assertThat(service.revoke("authorization-id")).isTrue();
+        verify(authorizationService).remove(authorization);
+    }
+
+    @Test
+    void shouldReturnFalseWhenAuthorizationDoesNotExist() {
+        when(authorizationService.findById("missing")).thenReturn(null);
+
+        assertThat(service.revoke("missing")).isFalse();
+    }
+}


### PR DESCRIPTION
## 变更内容

- 新增 OAuth2 授权记录分页查询和详情接口
- 支持按客户端、主体、授权类型和状态筛选
- 新增授权记录撤销接口，删除服务端授权记录
- 补充接口鉴权路径和撤销服务单元测试

## 验证

- 按提交要求未运行测试

## 关联改动

- base-organization：Token 管理菜单与权限
- opensabre-admin：Token 管理页面