### PR TITLE
feat: 增加失效 Token 清理能力

### DIFF
--- a/src/main/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepository.java
+++ b/src/main/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepository.java
@@ -69,6 +69,32 @@ public class OAuth2AuthorizationRecordRepository {
         return records.stream().findFirst();
     }
 
+    /**
+     * 删除至少签发过一种授权材料，且所有授权材料都已到期的聚合记录。
+     * 空有效期不视为过期，防止误删尚未签发Token的授权码或设备码流程。
+     *
+     * @param expiredBefore 过期截止时间
+     * @return 删除记录数
+     */
+    public int deleteExpired(Instant expiredBefore) {
+        Timestamp cutoff = Timestamp.from(expiredBefore);
+        return jdbcTemplate.update("""
+                DELETE FROM oauth2_authorization
+                 WHERE (authorization_code_expires_at IS NOT NULL
+                     OR access_token_expires_at IS NOT NULL
+                     OR oidc_id_token_expires_at IS NOT NULL
+                     OR refresh_token_expires_at IS NOT NULL
+                     OR user_code_expires_at IS NOT NULL
+                     OR device_code_expires_at IS NOT NULL)
+                   AND (authorization_code_expires_at IS NULL OR authorization_code_expires_at <= ?)
+                   AND (access_token_expires_at IS NULL OR access_token_expires_at <= ?)
+                   AND (oidc_id_token_expires_at IS NULL OR oidc_id_token_expires_at <= ?)
+                   AND (refresh_token_expires_at IS NULL OR refresh_token_expires_at <= ?)
+                   AND (user_code_expires_at IS NULL OR user_code_expires_at <= ?)
+                   AND (device_code_expires_at IS NULL OR device_code_expires_at <= ?)
+                """, cutoff, cutoff, cutoff, cutoff, cutoff, cutoff);
+    }
+
     private SqlCondition buildCondition(OAuth2AuthorizationQueryParam param) {
         StringBuilder where = new StringBuilder(" WHERE 1 = 1");
         List<Object> arguments = new ArrayList<>();

--- a/src/main/java/io/github/opensabre/authorization/rest/OAuth2AuthorizationRecordController.java
+++ b/src/main/java/io/github/opensabre/authorization/rest/OAuth2AuthorizationRecordController.java
@@ -58,4 +58,17 @@ public class OAuth2AuthorizationRecordController {
             @Parameter(description = "授权记录ID", required = true) @PathVariable String id) {
         return authorizationRecordService.revoke(id);
     }
+
+    @Operation(
+            summary = "清理已失效OAuth2授权记录",
+            description = "仅删除所有Token、授权码和设备码均已过期的服务端授权记录")
+    @DeleteMapping("/expired/cleanup")
+    @Audit(
+            operationType = OperationType.DELETE,
+            description = "清理已失效OAuth2授权记录",
+            module = "OAUTH2_AUTHORIZATION",
+            response = true)
+    public Integer cleanupExpired() {
+        return authorizationRecordService.cleanupExpired();
+    }
 }

--- a/src/main/java/io/github/opensabre/authorization/service/IOAuth2AuthorizationRecordService.java
+++ b/src/main/java/io/github/opensabre/authorization/service/IOAuth2AuthorizationRecordService.java
@@ -19,4 +19,11 @@ public interface IOAuth2AuthorizationRecordService {
      * @return 记录存在并已删除时返回true
      */
     boolean revoke(String id);
+
+    /**
+     * 删除所有授权材料均已过期的OAuth2授权记录。
+     *
+     * @return 删除的授权记录数
+     */
+    int cleanupExpired();
 }

--- a/src/main/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordService.java
+++ b/src/main/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordService.java
@@ -10,6 +10,8 @@ import org.springframework.security.oauth2.server.authorization.OAuth2Authorizat
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+
 @Service
 public class OAuth2AuthorizationRecordService implements IOAuth2AuthorizationRecordService {
 
@@ -42,5 +44,11 @@ public class OAuth2AuthorizationRecordService implements IOAuth2AuthorizationRec
         }
         authorizationService.remove(authorization);
         return true;
+    }
+
+    @Override
+    public int cleanupExpired() {
+        // 以同一个时间点判断所有授权材料，避免清理过程中跨秒导致边界不一致。
+        return repository.deleteExpired(Instant.now());
     }
 }

--- a/src/test/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepositoryTest.java
+++ b/src/test/java/io/github/opensabre/authorization/dao/OAuth2AuthorizationRecordRepositoryTest.java
@@ -40,8 +40,12 @@ class OAuth2AuthorizationRecordRepositoryTest {
                     access_token_type VARCHAR(100),
                     access_token_issued_at TIMESTAMP,
                     access_token_expires_at TIMESTAMP,
+                    authorization_code_expires_at TIMESTAMP,
+                    oidc_id_token_expires_at TIMESTAMP,
                     refresh_token_issued_at TIMESTAMP,
                     refresh_token_expires_at TIMESTAMP,
+                    user_code_expires_at TIMESTAMP,
+                    device_code_expires_at TIMESTAMP,
                     oidc_id_token_value BLOB,
                     device_code_value BLOB
                 )
@@ -62,6 +66,22 @@ class OAuth2AuthorizationRecordRepositoryTest {
         assertThat(query("ACTIVE")).containsExactly("active");
         assertThat(query("REFRESHABLE")).containsExactly("refreshable");
         assertThat(query("EXPIRED")).containsExactly("expired");
+    }
+
+    @Test
+    void shouldDeleteOnlyRecordsWhoseEveryAuthorizationMaterialHasExpired() {
+        Instant now = Instant.now();
+        insert("expired", now.minusSeconds(120), now.minusSeconds(60), now.minusSeconds(1));
+        insert("refreshable", now.minusSeconds(30), now.minusSeconds(1), now.plusSeconds(120));
+        insert("active-device-code", now.minusSeconds(30), now.minusSeconds(1), now.minusSeconds(1));
+        jdbcTemplate.update(
+                "UPDATE oauth2_authorization SET device_code_expires_at = ? WHERE id = ?",
+                Timestamp.from(now.plusSeconds(60)), "active-device-code");
+
+        assertThat(repository.deleteExpired(now)).isEqualTo(1);
+        assertThat(jdbcTemplate.queryForList(
+                "SELECT id FROM oauth2_authorization ORDER BY id", String.class))
+                .containsExactly("active-device-code", "refreshable");
     }
 
     private java.util.List<String> query(String status) {

--- a/src/test/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordServiceTest.java
+++ b/src/test/java/io/github/opensabre/authorization/service/impl/OAuth2AuthorizationRecordServiceTest.java
@@ -34,4 +34,12 @@ class OAuth2AuthorizationRecordServiceTest {
 
         assertThat(service.revoke("missing")).isFalse();
     }
+
+    @Test
+    void shouldDeleteExpiredAuthorizationsUsingCurrentCutoff() {
+        when(repository.deleteExpired(org.mockito.ArgumentMatchers.any())).thenReturn(3);
+
+        assertThat(service.cleanupExpired()).isEqualTo(3);
+        verify(repository).deleteExpired(org.mockito.ArgumentMatchers.any());
+    }
 }


### PR DESCRIPTION
## 变更
- 新增已失效 OAuth2 授权记录清理 API
- 仅清理所有 Token、授权码和设备码均过期的聚合
- 增加审计记录与安全边界测试

## 验证
- OAuth2AuthorizationRecordRepositoryTest 通过
- 项目编译通过