### PR TITLE
fix: 编译产物后再构建授权服务镜像

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -80,6 +80,7 @@ jobs:
         run: >-
           mvn --batch-mode --no-transfer-progress
           -DskipTests
+          compile
           jib:build
           -Dsecret.id=${{ secrets.DOCKER_CLOUD_SECRET_ID }}
           -Dsecret.key=${{ secrets.DOCKER_CLOUD_SECRET_KEY }}


### PR DESCRIPTION
## 修复
#23 将测试与镜像构建拆分为两个独立 Job 后，镜像 Job 没有共享前一 Job 的 `target/classes`，直接执行 `jib:build` 导致 master 发布失败。

在镜像 Job 中先执行 `compile`，测试仍由前置 `Maven Verify` 门禁负责且必须成功。

关联失败运行：30461796040。