### PR TITLE
feat: 接入框架公共配置

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>opensabre-base-dependencies</artifactId>
         <groupId>io.github.opensabre</groupId>
-        <version>0.7.1</version>
+        <version>0.7.3</version>
     </parent>
 
     <properties>
@@ -38,6 +38,10 @@
         <dependency>
             <groupId>io.github.opensabre</groupId>
             <artifactId>opensabre-starter-rpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.opensabre</groupId>
+            <artifactId>opensabre-starter-config</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.opensabre</groupId>


### PR DESCRIPTION
应用改为复用 opensabre-starter-config 0.7.3，由框架统一加载 Nacos 公共配置。