### PR TITLE
chore: 升级 Framework 至 0.7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>opensabre-base-dependencies</artifactId>
         <groupId>io.github.opensabre</groupId>
-        <version>0.7.4</version>
+        <version>0.7.6</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
升级 opensabre-base-dependencies 至 0.7.6。\n\n验证：JDK 21 下 mvn clean test，16 个测试全部通过。