### PR TITLE
chore: 升级 Framework 0.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>opensabre-base-dependencies</artifactId>
         <groupId>io.github.opensabre</groupId>
-        <version>0.7.6</version>
+        <version>0.7.7</version>
     </parent>
 
     <properties>

--- a/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
+++ b/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
@@ -61,6 +61,8 @@ public class WebSecurityConfig {
                         .permitAll()
                         .requestMatchers("/login/captcha/image")
                         .permitAll()
+                        .requestMatchers("/actuator/internalTokenKeyStatus")
+                        .permitAll()
                         .requestMatchers(
                                 "/authorizations", "/authorizations/**",
                                 "/authorization-consents", "/authorization-consents/**")


### PR DESCRIPTION
## 变更
升级 Framework 0.7.7，并开放不含密钥的内部 Token 状态 Actuator 端点。

## 验证
- JDK 21 Maven clean verify 通过
- 从 Maven Central 解析 Framework 0.7.7