### PR TITLE
fix: 修复 Boot 4 认证回归

### DIFF
--- a/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
+++ b/src/main/java/io/github/opensabre/authorization/config/WebSecurityConfig.java
@@ -10,6 +10,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -86,6 +89,28 @@ public class WebSecurityConfig {
         httpSecurity.oauth2ResourceServer((resourceServer) -> resourceServer
                 .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)));
         return httpSecurity.build();
+    }
+
+    /**
+     * 配置 DaoAuthenticationProvider 用于用户名密码认证
+     *
+     * @return DaoAuthenticationProvider
+     */
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider() {
+        return new DaoAuthenticationProvider(userDetailsService);
+    }
+
+    /**
+     * 配置 AuthenticationManager
+     *
+     * @param authenticationConfiguration 认证配置
+     * @return AuthenticationManager
+     * @throws Exception 配置异常
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     /**

--- a/src/main/java/io/github/opensabre/authorization/oauth2/device/DeviceClientAuthenticationConverter.java
+++ b/src/main/java/io/github/opensabre/authorization/oauth2/device/DeviceClientAuthenticationConverter.java
@@ -41,7 +41,7 @@ public final class DeviceClientAuthenticationConverter implements Authentication
         }
         // client_id (REQUIRED)
         String clientId = request.getParameter(OAuth2ParameterNames.CLIENT_ID);
-        if (StringUtils.isNotBlank(clientId) || request.getParameterValues(OAuth2ParameterNames.CLIENT_ID).length != 1) {
+        if (StringUtils.isBlank(clientId) || request.getParameterValues(OAuth2ParameterNames.CLIENT_ID).length != 1) {
             throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);
         }
         return new DeviceClientAuthenticationToken(clientId, ClientAuthenticationMethod.NONE, null, null);

--- a/src/test/java/io/github/opensabre/authorization/config/WebSecurityConfigTest.java
+++ b/src/test/java/io/github/opensabre/authorization/config/WebSecurityConfigTest.java
@@ -1,14 +1,31 @@
 package io.github.opensabre.authorization.config;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SpringBootTest
+@ActiveProfiles("test")
 class WebSecurityConfigTest {
+
+    @Autowired(required = false)
+    private DaoAuthenticationProvider daoAuthenticationProvider;
+
+    @Autowired(required = false)
+    private AuthenticationManager authenticationManager;
+
+    @Autowired(required = false)
+    private UserDetailsService userDetailsService;
 
     @Test
     void shouldRestoreAuthoritiesFromJwtRolesClaim() {
@@ -28,5 +45,23 @@ class WebSecurityConfigTest {
         assertThat(authentication.getAuthorities())
                 .extracting("authority")
                 .contains("ADMIN", "IT");
+    }
+
+    @Test
+    void shouldConfigureDaoAuthenticationProvider() {
+        // Verify that DaoAuthenticationProvider is configured
+        assertThat(daoAuthenticationProvider).isNotNull();
+    }
+
+    @Test
+    void shouldConfigureAuthenticationManager() {
+        // Verify that AuthenticationManager is configured
+        assertThat(authenticationManager).isNotNull();
+    }
+
+    @Test
+    void shouldConfigureUserDetailsService() {
+        // Verify that UserDetailsService is configured
+        assertThat(userDetailsService).isNotNull();
     }
 }

--- a/src/test/java/io/github/opensabre/authorization/oauth2/device/DeviceClientAuthenticationConverterTest.java
+++ b/src/test/java/io/github/opensabre/authorization/oauth2/device/DeviceClientAuthenticationConverterTest.java
@@ -1,0 +1,49 @@
+package io.github.opensabre.authorization.oauth2.device;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests device client authentication request conversion.
+ */
+class DeviceClientAuthenticationConverterTest {
+
+    private static final String DEVICE_AUTHORIZATION_ENDPOINT = "/oauth2/device_authorization";
+
+    private final DeviceClientAuthenticationConverter converter =
+            new DeviceClientAuthenticationConverter(DEVICE_AUTHORIZATION_ENDPOINT);
+
+    @Test
+    void shouldConvertRequestWithSingleClientId() {
+        MockHttpServletRequest request = deviceAuthorizationRequest();
+        request.addParameter(OAuth2ParameterNames.CLIENT_ID, "device-client");
+
+        assertThat(converter.convert(request))
+                .isInstanceOf(DeviceClientAuthenticationToken.class)
+                .extracting("principal")
+                .isEqualTo("device-client");
+    }
+
+    @Test
+    void shouldRejectRequestWithDuplicateClientId() {
+        MockHttpServletRequest request = deviceAuthorizationRequest();
+        request.addParameter(OAuth2ParameterNames.CLIENT_ID, "device-client", "other-client");
+
+        assertThatThrownBy(() -> converter.convert(request))
+                .isInstanceOf(OAuth2AuthenticationException.class);
+    }
+
+    private MockHttpServletRequest deviceAuthorizationRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", DEVICE_AUTHORIZATION_ENDPOINT);
+        request.setServletPath(DEVICE_AUTHORIZATION_ENDPOINT);
+        request.addParameter(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.DEVICE_CODE.getValue());
+        request.addParameter(OAuth2ParameterNames.DEVICE_CODE, "device-code");
+        return request;
+    }
+}


### PR DESCRIPTION
## 修复内容
- 恢复用户名密码认证所需的 `DaoAuthenticationProvider` 与 `AuthenticationManager`
- 修正设备授权客户端 `client_id` 的合法性判断
- 增加认证 Bean 与设备客户端转换回归测试

## 验证
- `mvn clean test`：31 项通过
- 定向新增测试：2 项通过
- 服务器 `1.0.0-fixed` 已验证登录链路正常