### PR TITLE
fix: require authentication for OAuth2 authorization endpoint

### DIFF
--- a/src/main/java/io/github/opensabre/authorization/config/AuthorizationServerConfig.java
+++ b/src/main/java/io/github/opensabre/authorization/config/AuthorizationServerConfig.java
@@ -60,6 +60,10 @@ public class AuthorizationServerConfig {
         RequestMatcher endpointsMatcher = authorizationServerConfigurer.getEndpointsMatcher();
         httpSecurity
                 .securityMatcher(endpointsMatcher)
+                // Require a logged-in resource owner before the authorization endpoint
+                // processes the request; otherwise anonymous requests become
+                // `invalid_request: principal` callbacks instead of login redirects.
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .with(authorizationServerConfigurer, Customizer.withDefaults());
         // 自定义用户映射器
         Function<OidcUserInfoAuthenticationContext, OidcUserInfo> userInfoMapper = (context) -> {


### PR DESCRIPTION
## Problem
Anonymous authorization requests were redirected with `invalid_request: principal`, so the gateway never established a session and `/api/org/user/current` returned 302 `/login`.

## Fix
Require authentication on the authorization-server endpoint filter chain so browser requests reach the login entry point.

## Validation
- `mvn --batch-mode --no-transfer-progress test`
- 33 tests passed locally