### PR TITLE
fix: 客户端审计时间保留毫秒精度

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -12,6 +12,16 @@
 - 检查令牌声明、客户端校验和在线用户查询。
 - 变更数据库结构时同时验证空库初始化与升级脚本（若已提供）。
 
+## OAuth2 客户端审计时间迁移
+
+`V20260818_01__use_millisecond_precision_for_client_audit_timestamps.sql` 将
+`oauth2_registered_client` 的公共审计字段升级为 `DATETIME(3)`；`updated_time` 由
+`ON UPDATE CURRENT_TIMESTAMP(3)` 自动维护。该变更不调整授权记录的签发、过期等协议时间字段，
+以免改变 OAuth2 的过期与清理语义。
+
+迁移前已被秒级 `DATETIME` 截断的毫秒无法恢复。发布前备份目标库并记录迁移版本；回滚为
+`DATETIME` 会再次截断迁移后写入的毫秒。
+
 ## 变更要求
 
 - 修改 OAuth2 声明、Scope、登录校验或锁定策略时，更新 `modules/oauth2.md`。

--- a/src/main/resources/db/migrations/V20260722_01__fix_local_gateway_oauth2_redirect.sql
+++ b/src/main/resources/db/migrations/V20260722_01__fix_local_gateway_oauth2_redirect.sql
@@ -2,7 +2,7 @@
 UPDATE oauth2_registered_client
 SET redirect_uris = 'http://localhost:3000/login/oauth2/code/base-gateway-local',
     post_logout_redirect_uris = 'http://localhost:3000/login/oauth2/code/base-gateway-local',
-    updated_time = now(),
+    updated_time = now(3),
     updated_by = 'system'
 WHERE client_id = 'base-gateway-local'
   AND (redirect_uris <> 'http://localhost:3000/login/oauth2/code/base-gateway-local'

--- a/src/main/resources/db/migrations/V20260723_01__fix_local_gateway_oauth2_secret.sql
+++ b/src/main/resources/db/migrations/V20260723_01__fix_local_gateway_oauth2_secret.sql
@@ -2,7 +2,7 @@
 -- GATEWAY_LOCAL_OAUTH_CLIENT_SECRET default used by base-gateway.
 UPDATE oauth2_registered_client
 SET client_secret = '$2y$10$zjDbXviQ/DtuZ1d25DDDVux00UrjLmCGRNKL3kuEFmVxixfEpn7a.',
-    updated_time = NOW(),
+    updated_time = NOW(3),
     updated_by = 'system'
 WHERE client_id = 'base-gateway-local'
   AND client_secret <> '$2y$10$zjDbXviQ/DtuZ1d25DDDVux00UrjLmCGRNKL3kuEFmVxixfEpn7a.';

--- a/src/main/resources/db/migrations/V20260808_01__extend_gateway_refresh_token_ttl.sql
+++ b/src/main/resources/db/migrations/V20260808_01__extend_gateway_refresh_token_ttl.sql
@@ -5,7 +5,7 @@ SET token_settings = JSON_SET(
         '$."settings.token.refresh-token-time-to-live"',
         2592000
     ),
-    updated_time = CURRENT_TIMESTAMP,
+    updated_time = CURRENT_TIMESTAMP(3),
     updated_by = 'migration'
 WHERE client_id IN ('base-gateway', 'base-gateway-local', 'test_client1')
   AND (

--- a/src/main/resources/db/migrations/V20260818_01__use_millisecond_precision_for_client_audit_timestamps.sql
+++ b/src/main/resources/db/migrations/V20260818_01__use_millisecond_precision_for_client_audit_timestamps.sql
@@ -1,0 +1,4 @@
+-- Execute once in version order. DATETIME is timezone-neutral; previously truncated milliseconds cannot be recovered.
+ALTER TABLE oauth2_registered_client
+    MODIFY COLUMN created_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    MODIFY COLUMN updated_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间';

--- a/src/main/resources/db/os-base-auth-ddl.sql
+++ b/src/main/resources/db/os-base-auth-ddl.sql
@@ -56,7 +56,7 @@ CREATE TABLE oauth2_registered_client
 (
     id                            varchar(100)  NOT NULL COMMENT 'UUID生成',
     client_id                     varchar(100)  NOT NULL COMMENT 'client_id',
-    client_id_issued_at           datetime      NOT NULL DEFAULT now() COMMENT 'client生成时间',
+    client_id_issued_at           datetime      NOT NULL DEFAULT now(3) COMMENT 'client生成时间',
     client_secret                 varchar(200)           DEFAULT NULL COMMENT 'client密码',
     client_secret_expires_at      datetime               DEFAULT NULL COMMENT 'client密码过期时间',
     client_name                   varchar(200)  NOT NULL COMMENT 'client名称',
@@ -68,8 +68,8 @@ CREATE TABLE oauth2_registered_client
     client_settings               text          NOT NULL COMMENT 'client设置如：过期时间',
     token_settings                text          NOT NULL COMMENT 'token设置如：过期时间、类型等',
     deleted                       varchar(1)    NOT NULL DEFAULT 'N' COMMENT '是否已删除Y：已删除，N：未删除',
-    created_time                  datetime      NOT NULL DEFAULT now() COMMENT '创建时间',
-    updated_time                  datetime      NOT NULL DEFAULT now() COMMENT '更新时间',
+    created_time                  datetime(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    updated_time                  datetime(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
     created_by                    varchar(100)  NOT NULL COMMENT '创建人',
     updated_by                    varchar(100)  NOT NULL COMMENT '更新人',
     PRIMARY KEY (id)


### PR DESCRIPTION
## 变更\n- 将 OAuth2 客户端公共审计字段升级为 `DATETIME(3)`。\n- 保持授权记录签发、过期等协议时间字段的现有语义。\n\n## 验证\n- `mvn -Dtest=RegisteredClientMapperTest test`\n- GitHub Actions Maven Verify（本 PR）