### PR TITLE
build: upgrade to Framework 1.1.1 and Java 25

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5.6.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -72,7 +72,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5.6.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.springboot.cloud</groupId>
     <artifactId>base-authorization</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>base-authorization</name>
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>opensabre-base-dependencies</artifactId>
         <groupId>io.github.opensabre</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## Summary
- upgrade opensabre-base-dependencies and application version to 1.1.1
- run CI with JDK 25
- use Framework 1.1.1 optimized Java 25 Jib runtime

## Validation
- mvn verify (JDK 25)
- mvn -DskipTests -DREGISTRY_URL=registry.example.com/opensabre package jib:buildTar