### PR TITLE
fix: 验证码下游故障返回明确错误

### DIFF
--- a/src/main/java/io/github/opensabre/authorization/exception/AuthErrorType.java
+++ b/src/main/java/io/github/opensabre/authorization/exception/AuthErrorType.java
@@ -18,6 +18,7 @@ public enum AuthErrorType implements ErrorType {
     SERVER_ERROR("040050", "权限服务错误"),
     UNAUTHORIZED_CLIENT("040060", "未授权客户端"),
     UNAUTHORIZED("040061", "未授权"),
+    CAPTCHA_SERVICE_UNAVAILABLE("040080", "验证码服务暂不可用，请稍后重试"),
     UNSUPPORTED_RESPONSE_TYPE("040070", " 支持的响应类型"),
     UNSUPPORTED_GRANT_TYPE("040071", "不支持的授权类型");
 

--- a/src/main/java/io/github/opensabre/authorization/exception/CaptchaServiceUnavailableException.java
+++ b/src/main/java/io/github/opensabre/authorization/exception/CaptchaServiceUnavailableException.java
@@ -1,0 +1,13 @@
+package io.github.opensabre.authorization.exception;
+
+import io.github.opensabre.common.core.exception.BaseException;
+
+/**
+ * Indicates that the captcha dependency cannot serve the request.
+ */
+public class CaptchaServiceUnavailableException extends BaseException {
+
+    public CaptchaServiceUnavailableException() {
+        super(AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE);
+    }
+}

--- a/src/main/java/io/github/opensabre/authorization/exception/GlobalExceptionHandlerAdvice.java
+++ b/src/main/java/io/github/opensabre/authorization/exception/GlobalExceptionHandlerAdvice.java
@@ -28,4 +28,11 @@ public class GlobalExceptionHandlerAdvice {
         log.error("On Authentication Failure :{}", ex.getMessage());
         return Result.fail(AuthErrorType.INVALID_CLIENT);
     }
+
+    @ExceptionHandler(CaptchaServiceUnavailableException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public Result<?> captchaServiceUnavailable(CaptchaServiceUnavailableException ex) {
+        log.error("Captcha service unavailable", ex);
+        return Result.fail(AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE);
+    }
 }

--- a/src/main/java/io/github/opensabre/authorization/oauth2/login/LoginCaptchaAuthenticationFilter.java
+++ b/src/main/java/io/github/opensabre/authorization/oauth2/login/LoginCaptchaAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package io.github.opensabre.authorization.oauth2.login;
 
 import io.github.opensabre.authorization.provider.CaptchaProvider;
+import io.github.opensabre.authorization.exception.AuthErrorType;
 import io.github.opensabre.common.core.entity.vo.Result;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -44,17 +45,24 @@ public class LoginCaptchaAuthenticationFilter extends OncePerRequestFilter {
 
         String captchaId = request.getParameter("captchaId");
         String captchaCode = request.getParameter("captchaCode");
-        if (StringUtils.isAnyBlank(captchaId, captchaCode) || !verifyCaptcha(captchaId, captchaCode)) {
+        Result<Boolean> verification = verifyCaptcha(captchaId, captchaCode);
+        if (StringUtils.isAnyBlank(captchaId, captchaCode) || verification == null
+                || !verification.isSuccess() || !Boolean.TRUE.equals(verification.getData())) {
             log.warn("Login captcha verification failed: username={}", username);
-            response.sendRedirect(LoginRedirects.failureUrl(request, username, "captcha"));
+            String error = verification != null
+                    && AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE.getCode().equals(verification.getCode())
+                    ? "captcha-service-unavailable" : "captcha";
+            response.sendRedirect(LoginRedirects.failureUrl(request, username, error));
             return;
         }
 
         filterChain.doFilter(request, response);
     }
 
-    private boolean verifyCaptcha(String captchaId, String captchaCode) {
-        Result<Boolean> result = captchaProvider.verifyCaptcha(loginSecurityProperties.getCaptchaScenario(), captchaId, captchaCode);
-        return result != null && Boolean.TRUE.equals(result.getData());
+    private Result<Boolean> verifyCaptcha(String captchaId, String captchaCode) {
+        if (StringUtils.isAnyBlank(captchaId, captchaCode)) {
+            return null;
+        }
+        return captchaProvider.verifyCaptcha(loginSecurityProperties.getCaptchaScenario(), captchaId, captchaCode);
     }
 }

--- a/src/main/java/io/github/opensabre/authorization/provider/CaptchaProvider.java
+++ b/src/main/java/io/github/opensabre/authorization/provider/CaptchaProvider.java
@@ -6,7 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "base-sysadmin", contextId = "captchaProvider", fallback = CaptchaProviderFallback.class)
+@FeignClient(name = "base-sysadmin", contextId = "captchaProvider", fallbackFactory = CaptchaProviderFallbackFactory.class)
 public interface CaptchaProvider {
 
     @PostMapping(value = "/captcha/send/image")

--- a/src/main/java/io/github/opensabre/authorization/provider/CaptchaProviderFallback.java
+++ b/src/main/java/io/github/opensabre/authorization/provider/CaptchaProviderFallback.java
@@ -1,23 +1,32 @@
 package io.github.opensabre.authorization.provider;
 
 import io.github.opensabre.authorization.entity.CaptchaVo;
+import io.github.opensabre.authorization.exception.AuthErrorType;
 import io.github.opensabre.common.core.entity.vo.Result;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
 public class CaptchaProviderFallback implements CaptchaProvider {
+
+    private final Throwable cause;
+
+    public CaptchaProviderFallback() {
+        this(null);
+    }
+
+    public CaptchaProviderFallback(Throwable cause) {
+        this.cause = cause;
+    }
 
     @Override
     public Result<CaptchaVo> sendImageCaptcha(String scenario, String requestKey) {
-        log.warn("sendImageCaptcha downgrade");
-        return Result.success(new CaptchaVo());
+        log.warn("captcha image service unavailable: scenario={}, requestKey={}", scenario, requestKey, cause);
+        return Result.fail(AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE);
     }
 
     @Override
     public Result<Boolean> verifyCaptcha(String scenario, String captchaId, String inputCode) {
-        log.warn("verifyCaptcha downgrade");
-        return Result.success(false);
+        log.warn("captcha verify service unavailable: scenario={}, captchaId={}", scenario, captchaId, cause);
+        return Result.fail(AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE);
     }
 }

--- a/src/main/java/io/github/opensabre/authorization/provider/CaptchaProviderFallbackFactory.java
+++ b/src/main/java/io/github/opensabre/authorization/provider/CaptchaProviderFallbackFactory.java
@@ -1,0 +1,16 @@
+package io.github.opensabre.authorization.provider;
+
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Creates captcha fallbacks while preserving the downstream failure for logging.
+ */
+@Component
+public class CaptchaProviderFallbackFactory implements FallbackFactory<CaptchaProvider> {
+
+    @Override
+    public CaptchaProvider create(Throwable cause) {
+        return new CaptchaProviderFallback(cause);
+    }
+}

--- a/src/main/java/io/github/opensabre/authorization/rest/LoginCaptchaController.java
+++ b/src/main/java/io/github/opensabre/authorization/rest/LoginCaptchaController.java
@@ -1,10 +1,10 @@
 package io.github.opensabre.authorization.rest;
 
 import io.github.opensabre.authorization.entity.CaptchaVo;
+import io.github.opensabre.authorization.exception.CaptchaServiceUnavailableException;
 import io.github.opensabre.authorization.oauth2.login.LoginSecurityProperties;
 import io.github.opensabre.authorization.provider.CaptchaProvider;
 import io.github.opensabre.common.core.entity.vo.Result;
-import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,15 +12,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class LoginCaptchaController {
 
-    @Resource
-    private CaptchaProvider captchaProvider;
+    private final CaptchaProvider captchaProvider;
+    private final LoginSecurityProperties loginSecurityProperties;
 
-    @Resource
-    private LoginSecurityProperties loginSecurityProperties;
+    public LoginCaptchaController(CaptchaProvider captchaProvider, LoginSecurityProperties loginSecurityProperties) {
+        this.captchaProvider = captchaProvider;
+        this.loginSecurityProperties = loginSecurityProperties;
+    }
 
     @PostMapping("/login/captcha/image")
     public CaptchaVo imageCaptcha(HttpSession session) {
         Result<CaptchaVo> result = captchaProvider.sendImageCaptcha(loginSecurityProperties.getCaptchaScenario(), session.getId());
-        return result == null ? new CaptchaVo() : result.getData();
+        if (result == null || !result.isSuccess() || result.getData() == null) {
+            throw new CaptchaServiceUnavailableException();
+        }
+        return result.getData();
     }
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -56,6 +56,9 @@
                         <img id="captchaImage" alt="图形验证码">
                     </button>
                 </div>
+                <div th:if="${captchaRequired}" id="captchaError" class="text-danger small" role="alert" hidden>
+                    验证码服务暂不可用，请稍后重试。
+                </div>
             </div>
 
             <button class="btn btn-primary btn-signin" type="submit">登录</button>
@@ -80,6 +83,7 @@
         const captchaIdInput = document.getElementById('captchaId');
         const captchaImage = document.getElementById('captchaImage');
         const refreshButton = document.getElementById('refreshCaptcha');
+        const captchaError = document.getElementById('captchaError');
 
         function loadCaptcha() {
             fetch('/login/captcha/image', {method: 'POST'})
@@ -97,10 +101,12 @@
                     } else {
                         captchaImage.removeAttribute('src');
                     }
+                    captchaError.hidden = Boolean(captcha.captchaId && captcha.imageData);
                 })
                 .catch(function () {
                     captchaIdInput.value = '';
                     captchaImage.removeAttribute('src');
+                    captchaError.hidden = false;
                 });
         }
 

--- a/src/test/java/io/github/opensabre/authorization/provider/CaptchaProviderFallbackTest.java
+++ b/src/test/java/io/github/opensabre/authorization/provider/CaptchaProviderFallbackTest.java
@@ -1,0 +1,29 @@
+package io.github.opensabre.authorization.provider;
+
+import io.github.opensabre.authorization.exception.AuthErrorType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CaptchaProviderFallbackTest {
+
+    @Test
+    void shouldReturnFailureForImageCaptchaWhenDependencyIsUnavailable() {
+        var result = new CaptchaProviderFallback(new IllegalStateException("downstream unavailable"))
+                .sendImageCaptcha("LOGIN_IMAGE", "session-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getCode()).isEqualTo(AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE.getCode());
+        assertThat(result.getData()).isNull();
+    }
+
+    @Test
+    void shouldReturnFailureForVerificationWhenDependencyIsUnavailable() {
+        var result = new CaptchaProviderFallback(new IllegalStateException("downstream unavailable"))
+                .verifyCaptcha("LOGIN_IMAGE", "captcha-1", "1234");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getCode()).isEqualTo(AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE.getCode());
+        assertThat(result.getData()).isNull();
+    }
+}

--- a/src/test/java/io/github/opensabre/authorization/rest/LoginCaptchaControllerTest.java
+++ b/src/test/java/io/github/opensabre/authorization/rest/LoginCaptchaControllerTest.java
@@ -1,0 +1,44 @@
+package io.github.opensabre.authorization.rest;
+
+import io.github.opensabre.authorization.entity.CaptchaVo;
+import io.github.opensabre.authorization.exception.CaptchaServiceUnavailableException;
+import io.github.opensabre.authorization.oauth2.login.LoginSecurityProperties;
+import io.github.opensabre.authorization.provider.CaptchaProvider;
+import io.github.opensabre.common.core.entity.vo.Result;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LoginCaptchaControllerTest {
+
+    @Test
+    void shouldReturnCaptchaDataForSuccessfulProviderResponse() {
+        CaptchaProvider provider = mock(CaptchaProvider.class);
+        LoginSecurityProperties properties = new LoginSecurityProperties();
+        HttpSession session = mock(HttpSession.class);
+        CaptchaVo captcha = new CaptchaVo();
+        when(session.getId()).thenReturn("session-1");
+        when(provider.sendImageCaptcha("LOGIN_IMAGE", "session-1")).thenReturn(Result.success(captcha));
+
+        CaptchaVo result = new LoginCaptchaController(provider, properties).imageCaptcha(session);
+
+        assertThat(result).isSameAs(captcha);
+    }
+
+    @Test
+    void shouldRejectNullOrFailedProviderResponse() {
+        CaptchaProvider provider = mock(CaptchaProvider.class);
+        LoginSecurityProperties properties = new LoginSecurityProperties();
+        HttpSession session = mock(HttpSession.class);
+        when(session.getId()).thenReturn("session-1");
+        when(provider.sendImageCaptcha("LOGIN_IMAGE", "session-1"))
+                .thenReturn(Result.fail(io.github.opensabre.authorization.exception.AuthErrorType.CAPTCHA_SERVICE_UNAVAILABLE));
+
+        assertThatThrownBy(() -> new LoginCaptchaController(provider, properties).imageCaptcha(session))
+                .isInstanceOf(CaptchaServiceUnavailableException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- 修复验证码 Feign fallback 将下游故障伪装成成功空 CaptchaVo
- 使用标准错误码并返回 HTTP 503，保留下游失败原因日志
- 区分验证码依赖故障与普通验证码错误，并增加登录页提示
- 增加 fallback 与 Controller 回归测试

Closes #31

## Validation
- `mvn test`（37 tests passed）
- `mvn -DskipTests package`