### PR TITLE
Upgrade Authorization to Framework 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.springboot.cloud</groupId>
     <artifactId>base-authorization</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <name>base-authorization</name>
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>opensabre-base-dependencies</artifactId>
         <groupId>io.github.opensabre</groupId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <properties>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,8 @@ logging:
     org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: trace
     org.springframework.security.web.FilterChainProxy: trace # 过滤器执行顺序
     org.springframework.security.web.access.ExceptionTranslationFilter: trace #异常处理
+  pattern:
+    level: '%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-},%X{parentSpanId:-}]'
 
 mybatis-plus:
   global-config:


### PR DESCRIPTION
升级至 OpenSabre Framework 1.1.2，恢复标准链路日志格式并使用已发布的统一治理注册配置。\n\n本地 Maven 测试已通过；Organization 同步了既有菜单文案测试断言。